### PR TITLE
Updated the API's endpoint

### DIFF
--- a/lib/fastly_api.php
+++ b/lib/fastly_api.php
@@ -11,7 +11,7 @@ class FastlyAPI {
 	private $_user = null;
 	private $_customer = null;
 
-	private	$apphost = 'https://app.fastly.com';
+	private	$apphost = 'https://api.fastly.com';
 
 	public function __construct () {
 		$this->_curl_init();


### PR DESCRIPTION
I've updated the API class to use the correct domain ('api.fastly.com') for API calls.  It was incorrectly set to 'app.fastly.com'.