### PR TITLE
Fix: Sort out .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: php
-before_script:
-  - composer self-update
-  - composer install --prefer-source --no-interaction --dev
-script: 'vendor/bin/phpspec run'
+
 php:
   - 5.5
   - 5.6
+
+before_install:
+  - composer self-update
+
+install:
+  - composer install --prefer-source --no-interaction --dev
+
+script:
+  - vendor/bin/phpspec run


### PR DESCRIPTION
This PR

* [x] sorts out `.travis.yml`

💁 For reference, see https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle.