### PR TITLE
Fix: Validate composer.json and composer.lock on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
 
 before_install:
   - composer self-update
+  - composer validate
 
 install:
   - composer install --prefer-source --no-interaction --dev

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "fastly/fastly",
     "license": "MIT",
     "type": "Library",
+    "description": "Provides a PHP client for the Fastly API",
     "authors": [
         {
             "name": "Gonzalo Vilaseca",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "71115a8f9d346b05f5f937610a1e06c6",
+    "hash": "a7ac13f694b97e97f1fdb95c4cebaf89",
+    "content-hash": "0c008a4637f281c2a68338bcf3f90f25",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1008,6 +1009,8 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.5.0"
+    },
     "platform-dev": []
 }


### PR DESCRIPTION
❗ Blocked by #17.

This PR

* [x] validates `composer.json` and `composer.lock` in the `before_install` step
* [x] adds a missing description to `composer.json`
* [x] updates the outdated lock hash by running `composer update --lock`

💁 Running

```
$ composer validate
```

locally yields

```
See https://getcomposer.org/doc/04-schema.md for details on the schema
description : The property description is required
The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update`.
```