### PR TITLE
Fix: Add missing license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,16 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Fastly, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -85,3 +85,8 @@ TODO
 -----
 docs
 consistantly formatted docs
+
+License
+-----
+
+This package uses the MIT License (MIT). Please see [`LICENSE`](LICENSE) for more information.


### PR DESCRIPTION
This PR

* [x] adds a missing `LICENSE` file

💁 For reference, see https://opensource.org/licenses/MIT.