### PR TITLE
Fix: Run build against PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7
 
 before_install:
   - composer self-update


### PR DESCRIPTION
This PR

* [x] adds PHP 7 to the build matrix

Related to #20.