### PR TITLE
Fix: Remove --dev flag, as it is the default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - composer validate
 
 install:
-  - composer install --prefer-source --no-interaction --dev
+  - composer install --prefer-source --no-interaction
 
 script:
   - vendor/bin/phpspec run


### PR DESCRIPTION
This PR

* [x] removes the `--dev` flag when installing dependencies with `composer`, as it is the default

💁 For reference, see https://getcomposer.org/doc/03-cli.md#install:

> * **--dev**: Install packages listed in `require-dev` (this is the default behavior).