### PR TITLE
Fix: Disable xdebug as we don't need it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.6
 
 before_install:
+  - phpenv config-rm xdebug.ini
   - composer self-update
   - composer validate
 


### PR DESCRIPTION
This PR
- [x] disables xdebug on Travis

💁 This speeds up everything.
