### PR TITLE
Resolve undefined constant NEGATED_0

### DIFF
--- a/lib/Model/AclEntryResponse.php
+++ b/lib/Model/AclEntryResponse.php
@@ -237,7 +237,7 @@ class AclEntryResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $this->container['comment'] = $data['comment'] ?? null;
         $this->container['ip'] = $data['ip'] ?? null;
-        $this->container['negated'] = $data['negated'] ?? NEGATED_0;
+        $this->container['negated'] = $data['negated'] ?? self::NEGATED_0;
         $this->container['subnet'] = $data['subnet'] ?? null;
         $this->container['created_at'] = $data['created_at'] ?? null;
         $this->container['deleted_at'] = $data['deleted_at'] ?? null;


### PR DESCRIPTION
Resolve: PHP Warning:  Use of undefined constant NEGATED_0 - assumed 'NEGATED_0' (this will throw an Error in a future version of PHP) in .../fastly/vendor/fastly/fastly/lib/Model/AclEntryResponse.php on line 240