### PR TITLE
Resolve undefined constant NEGATED_0

### DIFF
--- a/lib/Model/AclEntry.php
+++ b/lib/Model/AclEntry.php
@@ -207,7 +207,7 @@ class AclEntry implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $this->container['comment'] = $data['comment'] ?? null;
         $this->container['ip'] = $data['ip'] ?? null;
-        $this->container['negated'] = $data['negated'] ?? NEGATED_0;
+        $this->container['negated'] = $data['negated'] ?? self::NEGATED_0;
         $this->container['subnet'] = $data['subnet'] ?? null;
     }
 


### PR DESCRIPTION
Resolve PHP Warning:  Use of undefined constant NEGATED_0 - assumed 'NEGATED_0' (this will throw an Error in a future version of PHP) in .../fastly/vendor/fastly/fastly/lib/Model/AclEntry.php on line 210