### PR TITLE
CI to automatically publish to Packagist

### DIFF
--- a/.github/scripts/pack.sh
+++ b/.github/scripts/pack.sh
@@ -1,0 +1,3 @@
+# make a package
+mkdir -p "${GITHUB_WORKSPACE}/dist"
+composer archive --format=zip --dir="${GITHUB_WORKSPACE}/dist" --file="${PACKAGE_FILENAME%.zip}"

--- a/.github/scripts/publish_env.sh
+++ b/.github/scripts/publish_env.sh
@@ -1,7 +1,7 @@
 # Parse the release tag
 
 # strip leading 'release/'
-TAG="${RELEASE_TAG#release/}"
+TAG="${GITHUB_REF_NAME#release/}"
 
 # strip leading v
 TAG_VALUE="${TAG#v}"

--- a/.github/scripts/publish_env.sh
+++ b/.github/scripts/publish_env.sh
@@ -1,0 +1,44 @@
+# Parse the release tag
+
+# strip leading 'release/'
+TAG="${RELEASE_TAG#release/}"
+
+# strip leading v
+TAG_VALUE="${TAG#v}"
+
+# strip trailing -dry
+VERSION="${TAG_VALUE%-dry}"
+
+# detect valid semver
+VALID_VERSION=$(npx -y semver-parser-cli@0.2.0 "${VERSION}" --field matches)
+if [ "${VALID_VERSION}" != "true" ]; then
+  exit 1
+fi
+
+# Packagist version numbers cannot have a fourth segment.
+# Check this by comparing pre and preid against each other, e.g.:
+# 1.0.1-alpha.0 would have: pre=alpha,0 preid=alpha
+# 1.0.1-alpha0 would have: pre=alpha0 preid=alpha0
+# 1.0.1 would have: pre=undefined preid=undefined
+PRE="$(npx -y semver-parser-cli@0.2.0 "${VERSION}" --field pre)"
+PRE_ID="$(npx -y semver-parser-cli@0.2.0 "${VERSION}" --field preid)"
+if [ "${PRE}" != "${PRE_ID}" ]; then
+  exit 1
+fi
+
+# Detect dry run mode
+DRY_RUN=0
+if [ "${TAG_VALUE}" != "${VERSION}" ]; then
+    DRY_RUN=1
+fi
+
+# publish tag ('alpha', 'beta', etc.)
+PUBLISH_TAG="${PRE_ID}"
+if [ "${PUBLISH_TAG}" == "undefined" ]; then
+  PUBLISH_TAG=latest
+fi
+
+echo "VERSION=${VERSION}"
+echo "DRY_RUN=${DRY_RUN}"
+echo "PUBLISH_TAG=${PUBLISH_TAG}"
+echo "PACKAGE_FILENAME=fastly-${VERSION}.zip"

--- a/.github/scripts/release_body.sh
+++ b/.github/scripts/release_body.sh
@@ -1,0 +1,25 @@
+printf '%s' "## ${API_CLIENT_NAME} API client v${VERSION}"
+
+if [ "${DRY_RUN}" == "1" ]; then
+  printf '%s' " (dry run)"
+fi
+
+echo ""
+
+# add a newline
+echo ""
+
+CODE_PATH=${CODE_PATH:-./}
+G_CODE=$(jq -r .G "${CODE_PATH}/sig.json")
+D_CODE=$(jq -r .D "${CODE_PATH}/sig.json")
+
+PACKAGE_FILESIZE=$(ls -lh "${GITHUB_WORKSPACE}/dist/${PACKAGE_FILENAME}" | awk '{print $5}')B
+
+echo "Artifact"
+echo " ${PACKAGE_FILENAME} (${PACKAGE_FILESIZE})"
+echo ""
+echo "Generated on: $(date)"
+echo "G-code: ${G_CODE}, D-code: ${D_CODE}"
+if [ "${PUBLISH_TAG}" != "latest" ]; then
+  echo "Pre-release Tag: ${PUBLISH_TAG}"
+fi

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -1,0 +1,60 @@
+name: Release CI
+on:
+  push:
+    tags:
+      - 'release/v?[0-9]*'
+
+env:
+  RELEASE_TAG: ${{ github.ref_name }}
+
+jobs:
+  publish:
+    name: Publish to Packagist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          path: main
+      - name: Set up environment variables
+        run: ./.github/scripts/publish_env.sh >> $GITHUB_ENV
+        working-directory: ./main
+        shell: bash
+      - name: Install PHP and Composer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "7.3"
+          tools: composer:v2
+      - name: Pack API client
+        run: ./.github/scripts/pack.sh
+        working-directory: ./main
+        shell: bash
+      - name: Create tag for Packagist (Dry run)
+        if: ${{ env.DRY_RUN == '1' }}
+        working-directory: ./main
+        run: echo "git tag v${{ env.VERSION }} && git push"
+        shell: bash
+      - name: Create tag for Packagist
+        if: ${{ env.DRY_RUN != '1' }}
+        working-directory: ./main
+        run: |
+          git tag v${{ env.VERSION }}
+          git push origin v${{ env.VERSION }}
+        shell: bash
+      - name: Write release body file
+        run: API_CLIENT_NAME=PHP CODE_PATH=./main ./main/.github/scripts/release_body.sh > ./dist/release_body.txt
+        shell: bash
+      - name: Create release (dry run)
+        if: ${{ env.DRY_RUN == '1' }}
+        run: cat ./dist/release_body.txt
+      - name: Create GitHub release
+        if: ${{ env.DRY_RUN != '1' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          name: v${{ env.VERSION }}
+          body_path: ./dist/release_body.txt
+          files: |
+            ./dist/${{ env.PACKAGE_FILENAME }}
+          draft: false
+          tag_name: v${{ env.VERSION }}
+          prerelease: ${{ env.PUBLISH_TAG != 'latest' }}

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -5,7 +5,7 @@ on:
       - 'release/v?[0-9]*'
 
 env:
-  RELEASE_TAG: ${{ github.ref_name }}
+  GITHUB_REF_NAME: ${{ github.ref_name }}
 
 jobs:
   publish:
@@ -32,7 +32,9 @@ jobs:
       - name: Create tag for Packagist (Dry run)
         if: ${{ env.DRY_RUN == '1' }}
         working-directory: ./main
-        run: echo "git tag v${{ env.VERSION }} && git push"
+        run: |
+          echo "git tag v${{ env.VERSION }}"
+          echo "git push origin v${{ env.VERSION }}"
         shell: bash
       - name: Create tag for Packagist
         if: ${{ env.DRY_RUN != '1' }}


### PR DESCRIPTION
This PR adds a publish mechanism to allow this API client to publish itself to Packagist and create a release in GitHub.

The input is to create a tag in this repo and push it, with the syntax: `release/[VERSION][-dry]`.

- `VERSION` should be the version number that the package should be published under, such as `v3.0.1` or `3.0.1-alpha0` (leading `v` is optional and ignored)
- Specify `-dry` if you want to do a "dry run" which doesn't actually publish to Packagist or create a release

This CI is intended to be used along with the client generator project, whose job it is to generate the newest API client code, tag it with said version code, and push it to this repo.

Unless running in `-dry` mode, this CI step will create a real version in Packagist, and a release in GitHub. Example run using `release/v1.0.1-alpha0` has generated the following:
 - CI run: https://github.com/fastly/fastly-php/actions/runs/3672807582
 - Packagist release: https://packagist.org/packages/fastly/fastly#v1.0.1-alpha0
 - An additional tag in GitHub: https://github.com/fastly/fastly-php/releases/tag/v1.0.1-alpha0
 - GitHub release: https://github.com/fastly/fastly-php/releases/tag/v1.0.1-alpha0
 - Artifact (composer package zip): https://github.com/fastly/fastly-php/releases/download/v1.0.1-alpha0/fastly-1.0.1-alpha0.zip
   - Note the artifact is added to the GitHub release as a release asset

If running in `-dry` mode, no actual Packagist publish or release will be made. Example run using `release/v1.0.1-alpha0-dry`:
 - CI run: https://github.com/fastly/fastly-php/actions/runs/3672807585
   - Click through this link into the "Publish to Packagist" job, and read the output of the "Create Release (Dry Run)" step. You'll see the following output:
      ```
      ## PHP API client v1.0.1-alpha0 (dry run)
      
      Artifact
       fastly-1.0.1-alpha0.zip (2.2MB)
      
      Generated on: Mon Dec 12 05:00:32 UTC 2022
      G-code: 8b4af0da, D-code: 237fa474
      Pre-release Tag: alpha0
      ```

This CI relies on Packagist's ability to "auto-update" from tags in the repo. Therefore this CI uses the `release/<VERSION>` syntax as input, but creates its own tag that looks like `v<VERSION>`. Packagist is notified of new tags via a Webhook, and creates a version by crawling it.