### PR TITLE
Fix for Creation of dynamic property Fastly\Configuration::$apiKeys is deprecated

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -128,6 +128,13 @@ class Configuration
     protected $rate_limit_reset = NULL;
 
     /**
+     * Associate array to store API key(s)
+     *
+     * @var string[]
+     */
+    protected array $apiKeys = [];
+
+    /**
      * Constructor
      */
     public function __construct()


### PR DESCRIPTION
## The Problem
Getting `Creation of dynamic property Fastly\Configuration::$apiKeys is deprecated` when using PHP 8.3.
Dynamic properties have been deprecated in PHP8.2.
`Fastly\Configuration` dynamically sets `$apiKeys` as an array.

## The Fix
Define the property to the class.
